### PR TITLE
ISSUE-56: Upstream breaking changes in AD1111 UI logic

### DIFF
--- a/javascript/dream_artist.js
+++ b/javascript/dream_artist.js
@@ -1,11 +1,29 @@
+const DA_PROGRESSBAR_LABEL = 'da_preview'
+const DA_GALLERY_LABEL = 'da_gallery'
+const DA_ERROR_LABEL = '#da_error'
+const DA_GALLERY_CHILD = 'da_gallery_kid';
+const DA_PROGRESS_LABEL = 'da_progress';
 
-function start_training_dreamartist(){
-    requestProgress('da')
-    gradioApp().querySelector('#da_error').innerHTML=''
+function start_training_dreamartist() {
+    rememberGallerySelection(DA_GALLERY_LABEL)
+    gradioApp().querySelector('#da_error').innerHTML = ''
+    var daGalleryElt = gradioApp().getElementById(DA_GALLERY_LABEL)
+    // set id of first child of daGalleryElt to 'da_gallery_kid',
+    // required by AUTOMATIC1111 UI Logic
+    daGalleryElt.children[0].id = DA_GALLERY_CHILD
+    var id = randomId();
+    requestProgress(id,
+        gradioApp().getElementById(DA_GALLERY_LABEL),
+        gradioApp().getElementById(DA_GALLERY_CHILD),
+        function () {
+        },
+        function (progress) {
+            gradioApp().getElementById(DA_PROGRESS_LABEL).innerHTML = progress.textinfo
+        })
 
-    return args_to_array(arguments)
+    const argsToArray = args_to_array(arguments);
+    argsToArray.push(argsToArray[0])
+    argsToArray[0] = id;
+    return argsToArray
 }
 
-onUiUpdate(function(){
-    check_progressbar('da', 'da_progressbar', 'da_progress_span', '', 'da_interrupt', 'da_preview', 'da_gallery')
-})

--- a/javascript/dream_artist.js
+++ b/javascript/dream_artist.js
@@ -22,7 +22,6 @@ function start_training_dreamartist() {
         })
 
     const argsToArray = args_to_array(arguments);
-    argsToArray.push(argsToArray[0])
     argsToArray[0] = id;
     return argsToArray
 }

--- a/scripts/dream_artist_main.py
+++ b/scripts/dream_artist_main.py
@@ -154,6 +154,10 @@ def on_ui_tabs():
             fn=wrap_gradio_gpu_call(dream_artist.ui.train_embedding, extra_outputs=[gr.update()]),
             _js="start_training_dreamartist",
             inputs=[
+                # this is a dummy argument because the first argument needs to be the TaskID, used in
+                # modules/call_queue.py to set the `task_id`.  The `task_id` is required for the live preview.
+                # the argsig of dreamartist.cptuning.train_embedding has been modified to take this into account
+                train_embedding_name,
                 train_embedding_name,
                 seed,
                 embedding_learn_rate,


### PR DESCRIPTION
Closes: https://github.com/7eu7d7/DreamArtist-sd-webui-extension/issues/49, https://github.com/7eu7d7/DreamArtist-sd-webui-extension/issues/56, and https://github.com/7eu7d7/DreamArtist-sd-webui-extension/issues/57

Major changes in the AD1111 UI in https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/d8b90ac121cbf0c18b1dc9d56a5e1d14ca51e74e lead to breaking changes with this plugin.

The major changes and fixes include:

1. In the client, `check_progress` has been superseded `requestProgress`
2. The first argument in the return function to `start_training_dreamartist` must be the taskId passed as the first argument to `requestProgress`
3. This required modifications in several of the backend functions to accommodate the new argument fixidy. 
4. `cfg_scale` is required to be a float in some places and a string in other places, so it was left as a string and cast to a `float` where necessary.
5. The dataset `ds` no longer has a `__len__` method.  The correct way to get the size is now `ds.batch_size`.  The appropriate calls were replaced.

Tested against https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/889b851a5260ce869a3286ad15d17d1bbb1da0a7