### PR TITLE
Fixed wrap_gradio_gpu_call import

### DIFF
--- a/scripts/dream_artist_main.py
+++ b/scripts/dream_artist_main.py
@@ -7,7 +7,7 @@ import modules
 from modules.ui import create_refresh_button, setup_progressbar, random_symbol
 from modules import sd_hijack, shared
 from modules.paths import script_path
-from webui import wrap_gradio_gpu_call
+from modules.call_queue import wrap_gradio_gpu_call
 import scripts.dream_artist as dream_artist
 import argparse
 


### PR DESCRIPTION
Small update/fix to dream_artist_main.py

I haven't used this extension in a while, but I'm assuming the import location for wrap_gradio_gpu_call was changed recently, causing the DreamArtist tab not to load at all.

Updated to import from modules.call_queue in stead of webui.  Tested and working